### PR TITLE
Create cookie popup and GDPR consent mechanism

### DIFF
--- a/frontend/public/index.html
+++ b/frontend/public/index.html
@@ -1,8 +1,15 @@
 <!DOCTYPE html>
 <html lang="en">
   <head>
-    <!-- Google Tag Manager -->
+    <!-- Cookie Consent Check and Conditional Loading -->
     <script>
+      // Check cookie consent before loading tracking scripts
+      function loadTrackingScripts() {
+        try {
+          const consent = localStorage.getItem("cookieConsent")
+          const consentData = consent ? JSON.parse(consent) : null
+
+          if (consentData?.preferences?.analytics) {
       ;(function (w, d, s, l, i) {
         w[l] = w[l] || []
         w[l].push({ "gtm.start": new Date().getTime(), event: "gtm.js" })
@@ -13,13 +20,22 @@
         j.src = "https://www.googletagmanager.com/gtm.js?id=" + i + dl
         f.parentNode.insertBefore(j, f)
       })(window, document, "script", "dataLayer", "GTM-M677X6V")
-    </script>
-    <!-- End Google Tag Manager -->
+          }
 
-    <!-- Google AdSense -->
-    <script async src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4082178684015354"
-     crossorigin="anonymous"></script>
-    <!-- End Google AdSense -->
+          if (consentData?.preferences?.advertising) {
+            var script = document.createElement("script")
+            script.src =
+              "https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-4082178684015354"
+            script.crossOrigin = "anonymous"
+            document.head.appendChild(script)
+          }
+        } catch (error) {
+          console.error("Error loading tracking scripts:", error)
+        }
+      }
+
+      loadTrackingScripts()
+    </script>
 
     <meta charset="utf-8" />
     <meta http-equiv="X-UA-Compatible" content="IE=edge" />
@@ -64,14 +80,19 @@
   </head>
   <body>
     <!-- Google Tag Manager (noscript) -->
-    <noscript
-      ><iframe
-        src="https://www.googletagmanager.com/ns.html?id=GTM-M677X6V"
-        height="0"
-        width="0"
-        style="display: none; visibility: hidden"
-      ></iframe
-    ></noscript>
+    <script>
+      try {
+        const consent = localStorage.getItem("cookieConsent")
+        const consentData = consent ? JSON.parse(consent) : null
+        if (consentData?.preferences?.analytics) {
+          document.write(
+            '<noscript><iframe src="https://www.googletagmanager.com/ns.html?id=GTM-M677X6V" height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>'
+          )
+        }
+      } catch (error) {
+        // Silent fail for noscript GTM
+      }
+    </script>
     <!-- End Google Tag Manager (noscript) -->
     <noscript>
       <strong

--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -17,6 +17,7 @@
       @input="handleUpgradeDialogInput"
     />
     <UpvoteRedditSnackbar />
+    <CookieConsent />
     <div
       v-if="showHeader"
       class="tw-fixed tw-z-40 tw-h-14 tw-w-screen tw-bg-white sm:tw-h-16"
@@ -252,6 +253,7 @@ import NewDialog from "./components/NewDialog.vue"
 import UpgradeDialog from "@/components/pricing/UpgradeDialog.vue"
 import SignInDialog from "@/components/SignInDialog.vue"
 import DiscordBanner from "@/components/DiscordBanner.vue"
+import CookieConsent from "@/components/CookieConsent.vue"
 
 export default {
   name: "App",
@@ -272,6 +274,7 @@ export default {
     UpgradeDialog,
     SignInDialog,
     DiscordBanner,
+    CookieConsent,
   },
 
   data: () => ({

--- a/frontend/src/components/CookieConsent.vue
+++ b/frontend/src/components/CookieConsent.vue
@@ -78,7 +78,7 @@
       <button
         v-else
         @click="acceptSelected"
-        class="tw-w-full tw-flex-1 tw-cursor-pointer tw-rounded-md tw-bg-blue tw-px-3 tw-py-2 tw-text-xs tw-font-medium tw-text-white sm:tw-w-auto"
+        class="tw-w-full tw-flex-1 tw-cursor-pointer tw-rounded-md tw-bg-blue tw-px-3 tw-py-2 tw-text-xs tw-font-medium tw-text-white"
       >
         Save
       </button>

--- a/frontend/src/components/CookieConsent.vue
+++ b/frontend/src/components/CookieConsent.vue
@@ -1,0 +1,116 @@
+<template>
+  <div v-if="showBanner" class="tw-fixed tw-bottom-5 tw-left-5 tw-w-80 tw-max-w-[calc(100vw-40px)] tw-bg-white tw-rounded-xl tw-shadow-2xl tw-z-50 max-[480px]:tw-bottom-2.5 max-[480px]:tw-left-2.5 max-[480px]:tw-w-[calc(100vw-20px)] max-[480px]:tw-max-w-none">
+    <div class="tw-flex tw-justify-between tw-items-center tw-px-4 tw-pt-4 tw-font-medium">
+      <h3>🍪 We use cookies</h3>
+      <button @click="showBanner = false" class="tw-bg-transparent tw-border-0 tw-text-xl tw-text-gray-400 tw-cursor-pointer tw-p-0 tw-w-6 tw-h-6 tw-flex tw-items-center tw-justify-center tw-rounded tw-transition-all tw-duration-200 hover:tw-bg-gray-100 hover:tw-text-gray-700">&times;</button>
+    </div>
+
+    <p class="tw-px-4 tw-py-2 tw-m-0 tw-text-xs tw-text-gray-600 tw-leading-tight">
+      We use cookies for analytics to improve our product. Choose your
+      preferences below.
+    </p>
+
+    <div class="tw-px-4 tw-py-2 tw-flex tw-flex-col tw-gap-2">
+      <v-checkbox v-model="preferences.necessary" disabled hide-details>
+        <template v-slot:label>
+          <span class="tw-flex-1 tw-text-gray-700 tw-font-medium tw-text-sm">Essential</span>
+        </template>
+      </v-checkbox>
+
+      <v-checkbox v-model="preferences.analytics" hide-details>
+        <template v-slot:label>
+          <span class="tw-flex-1 tw-text-gray-700 tw-font-medium tw-text-sm">Analytics</span>
+        </template>
+      </v-checkbox>
+
+      <v-checkbox v-model="preferences.advertising" hide-details>
+        <template v-slot:label>
+          <span class="tw-flex-1 tw-text-gray-700 tw-font-medium tw-text-sm">Advertising</span>
+        </template>
+      </v-checkbox>
+    </div>
+
+    <div class="tw-px-4 tw-py-3 tw-flex tw-gap-2 sm:tw-flex-row tw-flex-col sm:tw-w-auto">
+      <button @click="acceptSelected" class="tw-flex-1 tw-px-3 tw-py-2 tw-rounded-md tw-text-xs tw-font-medium tw-cursor-pointer tw-bg-blue tw-text-white sm:tw-w-auto tw-w-full">Save</button>
+      <button @click="acceptAll" class="tw-flex-1 tw-px-3 tw-py-2 tw-rounded-md tw-text-xs tw-font-medium tw-cursor-pointer tw-bg-green tw-text-white sm:tw-w-auto tw-w-full">Accept All</button>
+      <button @click="rejectAll" class="tw-flex-1 tw-px-3 tw-py-2 tw-rounded-md tw-text-xs tw-font-medium tw-cursor-pointer tw-bg-gray tw-text-very-dark-gray sm:tw-w-auto tw-w-full">Reject All</button>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: "CookieConsent",
+  data() {
+    return {
+      showBanner: false,
+      preferences: {
+        necessary: true,
+        analytics: true,
+        advertising: true,
+      },
+    }
+  },
+  created() {
+    this.checkConsentStatus()
+  },
+  methods: {
+    checkConsentStatus() {
+      const consent = localStorage.getItem("cookieConsent")
+      if (!consent) {
+        this.showBanner = true
+      } else {
+        try {
+          const consentData = JSON.parse(consent)
+          this.preferences = { ...consentData.preferences }
+        } catch (e) {
+          // malformed consent, show banner to reset
+          this.showBanner = true
+        }
+      }
+    },
+
+    acceptAll() {
+      this.preferences = {
+        necessary: true,
+        analytics: true,
+        advertising: true,
+      }
+      this.saveConsent()
+    },
+
+    rejectAll() {
+      this.preferences = {
+        necessary: true,
+        analytics: false,
+        advertising: false,
+      }
+      this.saveConsent()
+    },
+
+    acceptSelected() {
+      this.saveConsent()
+    },
+
+    saveConsent() {
+      const consentData = {
+        timestamp: new Date().toISOString(),
+        preferences: this.preferences,
+      }
+
+      localStorage.setItem("cookieConsent", JSON.stringify(consentData))
+      this.showBanner = false
+      window.location.reload()
+    },
+    goToSettings() {
+      this.$router.push({
+        name: "cookie-settings",
+        query: {
+          analytics: this.preferences.analytics ? "1" : "0",
+          advertising: this.preferences.advertising ? "1" : "0",
+        },
+      })
+    },
+  },
+}
+</script>

--- a/frontend/src/components/CookieConsent.vue
+++ b/frontend/src/components/CookieConsent.vue
@@ -6,7 +6,7 @@
     <div
       class="tw-flex tw-items-center tw-justify-between tw-px-4 tw-pt-4 tw-font-medium"
     >
-      <h3>We use cookies</h3>
+      <h3>We value your privacy</h3>
       <button
         @click="showBanner = false"
         class="tw-text-gray-400 hover:tw-bg-gray-100 hover:tw-text-gray-700 tw-flex tw-h-6 tw-w-6 tw-cursor-pointer tw-items-center tw-justify-center tw-rounded tw-border-0 tw-bg-transparent tw-p-0 tw-text-xl tw-transition-all tw-duration-200"
@@ -22,50 +22,65 @@
       preferences below.
     </p>
 
-    <div class="tw-flex tw-flex-col tw-gap-2 tw-px-4 tw-py-2">
-      <v-checkbox v-model="preferences.necessary" disabled hide-details>
-        <template v-slot:label>
-          <span class="tw-text-gray-700 tw-flex-1 tw-text-sm tw-font-medium"
-            >Essential</span
-          >
-        </template>
-      </v-checkbox>
+    <v-expand-transition>
+      <div
+        class="tw-flex tw-flex-col tw-gap-2 tw-px-4 tw-py-2"
+        v-if="showCustomizeSection"
+      >
+        <v-checkbox v-model="preferences.necessary" disabled hide-details>
+          <template v-slot:label>
+            <span class="tw-text-gray-700 tw-flex-1 tw-text-sm tw-font-medium"
+              >Essential</span
+            >
+          </template>
+        </v-checkbox>
 
-      <v-checkbox v-model="preferences.analytics" hide-details>
-        <template v-slot:label>
-          <span class="tw-text-gray-700 tw-flex-1 tw-text-sm tw-font-medium"
-            >Analytics</span
-          >
-        </template>
-      </v-checkbox>
+        <v-checkbox v-model="preferences.analytics" hide-details>
+          <template v-slot:label>
+            <span class="tw-text-gray-700 tw-flex-1 tw-text-sm tw-font-medium"
+              >Analytics</span
+            >
+          </template>
+        </v-checkbox>
 
-      <!-- <v-checkbox v-model="preferences.advertising" hide-details>
+        <!-- <v-checkbox v-model="preferences.advertising" hide-details>
         <template v-slot:label>
           <span class="tw-flex-1 tw-text-gray-700 tw-font-medium tw-text-sm">Advertising</span>
         </template>
       </v-checkbox> -->
-    </div>
+      </div>
+    </v-expand-transition>
 
-    <div
-      class="tw-flex tw-flex-col tw-gap-2 tw-px-4 tw-py-3 sm:tw-w-auto sm:tw-flex-row"
-    >
+    <div class="tw-px-4 tw-py-3">
+      <div
+        v-if="!showCustomizeSection"
+        class="tw-flex tw-flex-col tw-gap-2 sm:tw-w-auto sm:tw-flex-row"
+      >
+        <button
+          @click="showCustomizeSection = !showCustomizeSection"
+          class="tw-w-full tw-flex-1 tw-cursor-pointer tw-rounded-md tw-border tw-border-solid tw-border-gray tw-bg-white tw-px-3 tw-py-2 tw-text-xs tw-font-medium tw-text-very-dark-gray sm:tw-w-auto"
+        >
+          Customize
+        </button>
+        <button
+          @click="rejectAll"
+          class="tw-w-full tw-flex-1 tw-cursor-pointer tw-rounded-md tw-border tw-border-solid tw-border-gray tw-bg-white tw-px-3 tw-py-2 tw-text-xs tw-font-medium tw-text-very-dark-gray sm:tw-w-auto"
+        >
+          Reject all
+        </button>
+        <button
+          @click="acceptAll"
+          class="tw-w-full tw-flex-1 tw-cursor-pointer tw-rounded-md tw-bg-green tw-px-3 tw-py-2 tw-text-xs tw-font-medium tw-text-white sm:tw-w-auto"
+        >
+          Accept all
+        </button>
+      </div>
       <button
+        v-else
         @click="acceptSelected"
         class="tw-w-full tw-flex-1 tw-cursor-pointer tw-rounded-md tw-bg-blue tw-px-3 tw-py-2 tw-text-xs tw-font-medium tw-text-white sm:tw-w-auto"
       >
         Save
-      </button>
-      <button
-        @click="acceptAll"
-        class="tw-w-full tw-flex-1 tw-cursor-pointer tw-rounded-md tw-bg-green tw-px-3 tw-py-2 tw-text-xs tw-font-medium tw-text-white sm:tw-w-auto"
-      >
-        Accept All
-      </button>
-      <button
-        @click="rejectAll"
-        class="tw-w-full tw-flex-1 tw-cursor-pointer tw-rounded-md tw-bg-gray tw-px-3 tw-py-2 tw-text-xs tw-font-medium tw-text-very-dark-gray sm:tw-w-auto"
-      >
-        Reject All
       </button>
     </div>
   </div>
@@ -76,6 +91,7 @@ export default {
   name: "CookieConsent",
   data() {
     return {
+      showCustomizeSection: false,
       showBanner: false,
       preferences: {
         necessary: true,
@@ -133,7 +149,10 @@ export default {
 
       localStorage.setItem("cookieConsent", JSON.stringify(consentData))
       this.showBanner = false
-      window.location.reload()
+
+      if (!this.preferences.analytics) {
+        window.location.reload()
+      }
     },
     goToSettings() {
       this.$router.push({

--- a/frontend/src/components/CookieConsent.vue
+++ b/frontend/src/components/CookieConsent.vue
@@ -1,39 +1,72 @@
 <template>
-  <div v-if="showBanner" class="tw-fixed tw-bottom-5 tw-left-5 tw-w-80 tw-max-w-[calc(100vw-40px)] tw-bg-white tw-rounded-xl tw-shadow-2xl tw-z-50 max-[480px]:tw-bottom-2.5 max-[480px]:tw-left-2.5 max-[480px]:tw-w-[calc(100vw-20px)] max-[480px]:tw-max-w-none">
-    <div class="tw-flex tw-justify-between tw-items-center tw-px-4 tw-pt-4 tw-font-medium">
-      <h3>🍪 We use cookies</h3>
-      <button @click="showBanner = false" class="tw-bg-transparent tw-border-0 tw-text-xl tw-text-gray-400 tw-cursor-pointer tw-p-0 tw-w-6 tw-h-6 tw-flex tw-items-center tw-justify-center tw-rounded tw-transition-all tw-duration-200 hover:tw-bg-gray-100 hover:tw-text-gray-700">&times;</button>
+  <div
+    v-if="showBanner"
+    class="tw-fixed tw-bottom-5 tw-right-5 tw-z-50 tw-w-80 tw-max-w-[calc(100vw-40px)] tw-rounded-xl tw-bg-white tw-shadow-2xl max-[480px]:tw-bottom-2.5 max-[480px]:tw-left-2.5 max-[480px]:tw-w-[calc(100vw-20px)] max-[480px]:tw-max-w-none"
+  >
+    <div
+      class="tw-flex tw-items-center tw-justify-between tw-px-4 tw-pt-4 tw-font-medium"
+    >
+      <h3>We use cookies</h3>
+      <button
+        @click="showBanner = false"
+        class="tw-text-gray-400 hover:tw-bg-gray-100 hover:tw-text-gray-700 tw-flex tw-h-6 tw-w-6 tw-cursor-pointer tw-items-center tw-justify-center tw-rounded tw-border-0 tw-bg-transparent tw-p-0 tw-text-xl tw-transition-all tw-duration-200"
+      >
+        &times;
+      </button>
     </div>
 
-    <p class="tw-px-4 tw-py-2 tw-m-0 tw-text-xs tw-text-gray-600 tw-leading-tight">
+    <p
+      class="tw-text-gray-600 tw-m-0 tw-px-4 tw-py-2 tw-text-xs tw-leading-tight"
+    >
       We use cookies for analytics to improve our product. Choose your
       preferences below.
     </p>
 
-    <div class="tw-px-4 tw-py-2 tw-flex tw-flex-col tw-gap-2">
+    <div class="tw-flex tw-flex-col tw-gap-2 tw-px-4 tw-py-2">
       <v-checkbox v-model="preferences.necessary" disabled hide-details>
         <template v-slot:label>
-          <span class="tw-flex-1 tw-text-gray-700 tw-font-medium tw-text-sm">Essential</span>
+          <span class="tw-text-gray-700 tw-flex-1 tw-text-sm tw-font-medium"
+            >Essential</span
+          >
         </template>
       </v-checkbox>
 
       <v-checkbox v-model="preferences.analytics" hide-details>
         <template v-slot:label>
-          <span class="tw-flex-1 tw-text-gray-700 tw-font-medium tw-text-sm">Analytics</span>
+          <span class="tw-text-gray-700 tw-flex-1 tw-text-sm tw-font-medium"
+            >Analytics</span
+          >
         </template>
       </v-checkbox>
 
-      <v-checkbox v-model="preferences.advertising" hide-details>
+      <!-- <v-checkbox v-model="preferences.advertising" hide-details>
         <template v-slot:label>
           <span class="tw-flex-1 tw-text-gray-700 tw-font-medium tw-text-sm">Advertising</span>
         </template>
-      </v-checkbox>
+      </v-checkbox> -->
     </div>
 
-    <div class="tw-px-4 tw-py-3 tw-flex tw-gap-2 sm:tw-flex-row tw-flex-col sm:tw-w-auto">
-      <button @click="acceptSelected" class="tw-flex-1 tw-px-3 tw-py-2 tw-rounded-md tw-text-xs tw-font-medium tw-cursor-pointer tw-bg-blue tw-text-white sm:tw-w-auto tw-w-full">Save</button>
-      <button @click="acceptAll" class="tw-flex-1 tw-px-3 tw-py-2 tw-rounded-md tw-text-xs tw-font-medium tw-cursor-pointer tw-bg-green tw-text-white sm:tw-w-auto tw-w-full">Accept All</button>
-      <button @click="rejectAll" class="tw-flex-1 tw-px-3 tw-py-2 tw-rounded-md tw-text-xs tw-font-medium tw-cursor-pointer tw-bg-gray tw-text-very-dark-gray sm:tw-w-auto tw-w-full">Reject All</button>
+    <div
+      class="tw-flex tw-flex-col tw-gap-2 tw-px-4 tw-py-3 sm:tw-w-auto sm:tw-flex-row"
+    >
+      <button
+        @click="acceptSelected"
+        class="tw-w-full tw-flex-1 tw-cursor-pointer tw-rounded-md tw-bg-blue tw-px-3 tw-py-2 tw-text-xs tw-font-medium tw-text-white sm:tw-w-auto"
+      >
+        Save
+      </button>
+      <button
+        @click="acceptAll"
+        class="tw-w-full tw-flex-1 tw-cursor-pointer tw-rounded-md tw-bg-green tw-px-3 tw-py-2 tw-text-xs tw-font-medium tw-text-white sm:tw-w-auto"
+      >
+        Accept All
+      </button>
+      <button
+        @click="rejectAll"
+        class="tw-w-full tw-flex-1 tw-cursor-pointer tw-rounded-md tw-bg-gray tw-px-3 tw-py-2 tw-text-xs tw-font-medium tw-text-very-dark-gray sm:tw-w-auto"
+      >
+        Reject All
+      </button>
     </div>
   </div>
 </template>

--- a/frontend/src/components/CookieConsent.vue
+++ b/frontend/src/components/CookieConsent.vue
@@ -150,9 +150,7 @@ export default {
       localStorage.setItem("cookieConsent", JSON.stringify(consentData))
       this.showBanner = false
 
-      if (!this.preferences.analytics) {
-        window.location.reload()
-      }
+      window.location.reload()
     },
     goToSettings() {
       this.$router.push({

--- a/frontend/src/components/CookieSettings.vue
+++ b/frontend/src/components/CookieSettings.vue
@@ -1,0 +1,152 @@
+<template>
+  <div class="mx-auto tw-w-full md:tw-w-2/3 lg:tw-w-1/2 tw-px-5 tw-pt-10">
+    <h2 class="tw-mb-2.5 tw-text-xl tw-font-semibold">Cookie Preferences</h2>
+    <div class="tw-mb-5 tw-flex tw-flex-col tw-gap-6">
+      <div class="tw-rounded-lg tw-border tw-bg-white tw-p-5">
+        <v-checkbox v-model="preferences.necessary" disabled>
+          <template v-slot:label>
+            <div>
+              <strong class="tw-text-gray-800 tw-text-base tw-font-semibold">
+                Necessary Cookies
+              </strong>
+            </div>
+          </template>
+        </v-checkbox>
+        <div
+          class="tw-text-gray-600 tw-mt-4 tw-pl-0 tw-text-sm tw-leading-relaxed md:tw-mt-0 md:tw-pl-8"
+        >
+          <p>
+            These cookies are essential for the website to function properly.
+            They enable basic features like page navigation, user
+            authentication, and form submissions.
+          </p>
+        </div>
+      </div>
+
+      <div class="tw-rounded-lg tw-border tw-bg-white tw-p-5">
+        <v-checkbox v-model="preferences.analytics">
+          <template v-slot:label>
+            <div>
+              <strong class="tw-text-gray-800 tw-text-base tw-font-semibold">
+                Analytics Cookies
+              </strong>
+            </div>
+          </template>
+        </v-checkbox>
+        <div
+          class="tw-text-gray-600 tw-mt-4 tw-pl-0 tw-text-sm tw-leading-relaxed md:tw-mt-0 md:tw-pl-8"
+        >
+          <p>
+            <strong>Services used:</strong> PostHog Analytics, Google Analytics
+            (via Google Tag Manager)
+          </p>
+          <p>
+            These cookies help us understand how visitors interact with our
+            website by collecting and reporting information anonymously. This
+            helps us improve our website's performance and user experience.
+          </p>
+        </div>
+      </div>
+
+      <div class="tw-rounded-lg tw-border tw-bg-white tw-p-5">
+        <div>
+          <v-checkbox v-model="preferences.advertising">
+            <template v-slot:label>
+              <div>
+                <strong class="tw-text-gray-800 tw-text-base tw-font-semibold">
+                  Advertising Cookies
+                </strong>
+              </div>
+            </template>
+          </v-checkbox>
+        </div>
+        <div
+          class="tw-text-gray-600 tw-mt-4 tw-pl-0 tw-text-sm tw-leading-relaxed md:tw-mt-0 md:tw-pl-8"
+        >
+          <p><strong>Services used:</strong> Google AdSense</p>
+          <p>
+            These cookies are used to make advertising messages more relevant to
+            you. They may be set by our advertising partners through our site to
+            build a profile of your interests and show you relevant ads on other
+            sites.
+          </p>
+        </div>
+      </div>
+    </div>
+
+    <div class="tw-flex tw-flex-wrap tw-gap-2">
+      <button
+        @click="savePreferences"
+        class="tw-rounded-md tw-bg-blue tw-px-4 tw-py-2 tw-text-sm tw-font-medium tw-text-white hover:tw-bg-light-blue"
+      >
+        Save Preferences
+      </button>
+      <button
+        @click="acceptAll"
+        class="tw-rounded-md tw-bg-green tw-px-4 tw-py-2 tw-text-sm tw-font-medium tw-text-white hover:tw-bg-dark-green"
+      >
+        Accept All
+      </button>
+      <button
+        @click="rejectAll"
+        class="tw-rounded-md tw-px-4 tw-py-2 tw-text-sm tw-font-medium tw-text-white tw-bg-very-dark-gray"
+      >
+        Reject All (except necessary)
+      </button>
+    </div>
+  </div>
+</template>
+
+<script>
+import { getCookieConsent, setCookieConsent } from "@/utils/cookie_utils"
+
+export default {
+  name: "CookieSettings",
+  data() {
+    return {
+      preferences: {
+        necessary: true,
+        analytics: true,
+        advertising: true,
+      },
+    }
+  },
+  mounted() {
+    this.loadCurrentSettings()
+  },
+  methods: {
+    loadCurrentSettings() {
+      const consent = getCookieConsent()
+      if (consent) {
+        this.preferences = { ...consent.preferences }
+      }
+    },
+
+    savePreferences() {
+      this.saveConsent()
+    },
+
+    acceptAll() {
+      this.preferences = {
+        necessary: true,
+        analytics: true,
+        advertising: true,
+      }
+      this.saveConsent()
+    },
+
+    rejectAll() {
+      this.preferences = {
+        necessary: true,
+        analytics: false,
+        advertising: false,
+      }
+      this.saveConsent()
+    },
+    saveConsent() {
+      setCookieConsent(this.preferences)
+      window.location.reload()
+    },
+  },
+}
+</script>

--- a/frontend/src/components/Footer.vue
+++ b/frontend/src/components/Footer.vue
@@ -70,7 +70,14 @@
               </svg>
             </a>
           </div>
-          <a href="/privacy-policy" class="tw-text-sm">Privacy Policy</a>
+          <div class="tw-flex tw-flex-col tw-gap-2">
+            <router-link :to="{ name: 'privacy-policy' }" class="tw-text-sm">
+              Privacy Policy
+            </router-link>
+            <router-link :to="{ name: 'cookie-settings' }" class="tw-text-sm">
+              Cookie Preferences
+            </router-link>
+          </div>
         </div>
         <!-- Links -->
         <div class="tw-flex tw-flex-col tw-gap-2">

--- a/frontend/src/main.js
+++ b/frontend/src/main.js
@@ -7,17 +7,19 @@ import vuetify from "./plugins/vuetify"
 import posthogPlugin from "./plugins/posthog"
 import VueGtm from "@gtm-support/vue2-gtm"
 import VueMeta from "vue-meta"
+import { initializeGTMConsent, hasAnalyticsConsent } from "./utils/cookie_utils"
 import "./index.css"
 
+initializeGTMConsent()
+
 // Posthog
-// if (process.env.NODE_ENV !== "development") {
 Vue.use(posthogPlugin)
-// }
 
 // Google Analytics
 Vue.use(VueGtm, {
   id: "GTM-M677X6V",
   vueRouter: router,
+  enabled: hasAnalyticsConsent(),
 })
 
 // Site Metadata

--- a/frontend/src/plugins/posthog.js
+++ b/frontend/src/plugins/posthog.js
@@ -1,11 +1,20 @@
 import posthog from "posthog-js"
+import { getCookieConsent } from "@/utils/cookie_utils"
 
 export default {
   install(Vue, options) {
+    // Initialize PostHog with capturing disabled by default
     Vue.prototype.$posthog = posthog.init(process.env.VUE_APP_POSTHOG_API_KEY, {
       api_host: "https://e.timeful.app",
       capture_pageview: false,
       autocapture: false,
+      opt_out_capturing_by_default: true,
     })
+
+    // If the user has previously given analytics consent in localStorage, opt-in
+    const consent = getCookieConsent()
+    if (consent && consent.preferences && consent.preferences.analytics) {
+      Vue.prototype.$posthog.opt_in_capturing()
+    }
   },
 }

--- a/frontend/src/router/index.js
+++ b/frontend/src/router/index.js
@@ -57,6 +57,11 @@ const routes = [
     component: () => import("@/views/PrivacyPolicy.vue"),
   },
   {
+    path: "/cookie-settings",
+    name: "cookie-settings",
+    component: () => import("@/components/CookieSettings.vue"),
+  },
+  {
     path: "/stripe-redirect",
     name: "stripe-redirect",
     component: () => import("@/views/StripeRedirect.vue"),

--- a/frontend/src/utils/cookie_utils.js
+++ b/frontend/src/utils/cookie_utils.js
@@ -1,0 +1,65 @@
+// Cookie consent utilities
+export const COOKIE_CONSENT_KEY = "cookieConsent"
+
+export function getCookieConsent() {
+  try {
+    const consent = localStorage.getItem(COOKIE_CONSENT_KEY)
+    if (!consent) return null
+
+    return JSON.parse(consent)
+  } catch (error) {
+    console.error("Error parsing cookie consent:", error)
+    return null
+  }
+}
+
+export function setCookieConsent(preferences) {
+  const consentData = {
+    timestamp: new Date().toISOString(),
+    preferences: {
+      necessary: true, // Always true
+      analytics: Boolean(preferences.analytics),
+      advertising: Boolean(preferences.advertising),
+    },
+  }
+
+  localStorage.setItem(COOKIE_CONSENT_KEY, JSON.stringify(consentData))
+  return consentData
+}
+
+export function hasAnalyticsConsent() {
+  const consent = getCookieConsent()
+  return consent?.preferences?.analytics === true
+}
+
+export function hasAdvertisingConsent() {
+  const consent = getCookieConsent()
+  return consent?.preferences?.advertising === true
+}
+
+export function hasGivenConsent() {
+  return getCookieConsent() !== null
+}
+
+// Initialize Google Tag Manager consent
+export function initializeGTMConsent() {
+  if (!window.dataLayer) {
+    window.dataLayer = []
+  }
+
+  const consent = getCookieConsent()
+  if (consent) {
+    window.dataLayer.push({
+      event: "consent_default",
+      analytics_consent: consent.preferences.analytics ? "granted" : "denied",
+      ad_consent: consent.preferences.advertising ? "granted" : "denied",
+    })
+  } else {
+    window.dataLayer.push({
+      event: "consent_default",
+      analytics_consent: "granted",
+      ad_consent: "granted",
+    })
+  }
+}
+


### PR DESCRIPTION
Closes #132 

This PR adds a cookie popup and cookie settings page to comply with GDPR. See below for examples.

Please note that this is a somewhat hacky solution by reloading the page to re-initialize Posthog and Google services. In future, it should instead dynamically toggle/reinitialize Posthog and Google services without having to reload. In the meantime, this should be adequate to ensure the project complies with GDPR regulations.

Also, I'm most familiar with Vue 3, so my apologies if I've not met some best practices for Vue 2, feedback is welcome!

<details>
<summary>Examples</summary>

Desktop popup:
<img width="562" height="506" alt="image" src="https://github.com/user-attachments/assets/a95c8502-fdb7-4d6f-922b-cb8c65ae9938" />

Mobile popup:
<img width="460" height="952" alt="image" src="https://github.com/user-attachments/assets/6824e13c-7511-4e37-8a2e-a2eee5745a6d" />

Desktop settings:
<img width="1695" height="945" alt="image" src="https://github.com/user-attachments/assets/257d0298-b779-4dcc-8596-0b3263a1a76f" />

Mobile settings:
<img width="550" height="1196" alt="image" src="https://github.com/user-attachments/assets/c9591aac-9cfa-49ed-8de2-ee380095c885" />

</details>
